### PR TITLE
graphix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,20 @@
 cmake_minimum_required(VERSION 3.22)
-project(robotintro)
+project(robotintro LANGUAGES CXX)
+
+# Added for SFML
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
+include(FetchContent)
+FetchContent_Declare(SFML
+    GIT_REPOSITORY https://github.com/SFML/SFML.git
+    GIT_TAG 2.6.x)
+FetchContent_MakeAvailable(SFML)
+
+# end added for SFML
+
 add_executable(robotintro main.cpp robotlib.cpp)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -g")
@@ -13,3 +25,5 @@ find_package(Catch2 3 REQUIRED)
 # These tests can use the Catch2-provided main
 add_executable(tests test.cpp)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
+
+install(TARGETS robotintro)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -g")
+set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
 
 include_directories(../eigen)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.22)
 project(robotintro LANGUAGES CXX)
 
 # Added for SFML
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 include(FetchContent)
@@ -13,6 +14,8 @@ FetchContent_MakeAvailable(SFML)
 # end added for SFML
 
 add_executable(robotintro main.cpp robotlib.cpp)
+target_link_libraries(robotintro PRIVATE sfml-graphics)
+target_compile_features(robotintro PRIVATE cxx_std_17)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -26,4 +29,3 @@ find_package(Catch2 3 REQUIRED)
 add_executable(tests test.cpp)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
 
-install(TARGETS robotintro)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_MakeAvailable(SFML)
 
 # end added for SFML
 
-add_executable(robotintro main.cpp robotlib.cpp)
+add_executable(robotintro main.cpp robotlib.cpp robotgfx.cpp)
 target_link_libraries(robotintro PRIVATE sfml-graphics)
 target_compile_features(robotintro PRIVATE cxx_std_17)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,7 +231,7 @@ int main() {
     m.set_tool(Vector3d(0.1, 0.2, 30));
     cout << m.tool_position() << endl;
 
-    auto window = sf::RenderWindow{{800, 600u}, "Robot Intro!"};
+    sf::RenderWindow window(sf::VideoMode(800, 600), "Robot Intro!");
     window.setFramerateLimit(144);
 
     while (window.isOpen()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,11 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
-#include <SFML/Graphics.hpp>
 #include <cmath>
 #include <iostream>
 #include <iterator>
 #include <vector>
 
+#include "robotgfx.h"
 #include "robotlib.h"
 
 using Eigen::Matrix2d;
@@ -14,135 +14,6 @@ using Eigen::Vector2d;
 using Eigen::Vector3d;
 
 using namespace std;
-
-// multiply meters by this number to get into graphics.
-const double SFML_SCALE = 300.f;
-
-sf::VertexArray world_axis(sf::RenderWindow& window, sf::Color axes_color) {
-    // Create the X and Y axes
-    sf::VertexArray xyAxis(sf::Lines, 4);
-
-    // Set the position of the axes
-    float xAxisLength = window.getSize().x;
-    float yAxisLength = window.getSize().y;
-    float xOffset = window.getSize().x / 2.f;
-    float yOffset = window.getSize().y / 2.f;
-
-    // Define the X axis
-    xyAxis[0].position = sf::Vector2f(-xAxisLength, yOffset);
-    xyAxis[1].position = sf::Vector2f(xAxisLength, yOffset);
-
-    // Define the Y axis
-    xyAxis[2].position = sf::Vector2f(xOffset, -yAxisLength);
-    xyAxis[3].position = sf::Vector2f(xOffset, yAxisLength);
-
-    // Set the color of the axes
-    for (int i = 0; i < 4; i++) {
-        xyAxis[i].color = axes_color;
-    }
-
-    return xyAxis;
-}
-
-sf::Vector2f _transform_point(sf::Vector2f point_m, sf::RenderWindow& window) {
-    sf::Vector2u win_size = window.getSize();
-    double x_offset = win_size.x / 2.f + point_m.x * SFML_SCALE;
-    double y_offset = win_size.y / 2.f - point_m.y * SFML_SCALE;
-
-    return sf::Vector2f(x_offset, y_offset);
-}
-
-sf::VertexArray gfx_frame(Vector3d frame, sf::RenderWindow& window,
-                          sf::Color axes_color) {
-    const float AXIS_LENGTH = 100.0f;  // Length of the axes in pixels
-    const float ARROW_SIZE = 10.0f;    // Size of the arrowhead in pixels
-
-    sf::VertexArray frame_vtx(sf::Lines);
-
-    sf::Vector2f origin_m(frame[0], frame[1]);
-    // Transform the origin from world coordinates to SFML window coordinates
-    sf::Vector2f origin_px = _transform_point(origin_m, window);
-
-    // Calculate the rotation angle in radians
-    float angle_rad = -radians(frame[2]);
-
-    // Calculate the X-axis endpoints
-    sf::Vector2f x_start(origin_px.x, origin_px.y);
-    sf::Vector2f x_end(origin_px.x + AXIS_LENGTH * cos(angle_rad),
-                       origin_px.y + AXIS_LENGTH * sin(angle_rad));
-
-    // Calculate the Y-axis endpoints
-    sf::Vector2f y_start(origin_px.x, origin_px.y);
-    sf::Vector2f y_end(origin_px.x + AXIS_LENGTH * sin(angle_rad),
-                       origin_px.y - AXIS_LENGTH * cos(angle_rad));
-
-    // Draw the X-axis
-    frame_vtx.append(sf::Vertex(x_start, axes_color));
-    frame_vtx.append(sf::Vertex(x_end, axes_color));
-
-    // Draw the arrowhead for the X-axis
-    sf::Vector2f x_arrow_start1(
-        x_end.x - ARROW_SIZE * cos(angle_rad) - ARROW_SIZE * sin(angle_rad),
-        x_end.y - ARROW_SIZE * sin(angle_rad) + ARROW_SIZE * cos(angle_rad));
-    sf::Vector2f x_arrow_end1(x_end.x, x_end.y);
-    frame_vtx.append(sf::Vertex(x_arrow_start1, axes_color));
-    frame_vtx.append(sf::Vertex(x_arrow_end1, axes_color));
-
-    sf::Vector2f x_arrow_start2(
-        x_end.x - ARROW_SIZE * cos(angle_rad) + ARROW_SIZE * sin(angle_rad),
-        x_end.y - ARROW_SIZE * sin(angle_rad) - ARROW_SIZE * cos(angle_rad));
-    sf::Vector2f x_arrow_end2(x_end.x, x_end.y);
-    frame_vtx.append(sf::Vertex(x_arrow_start2, axes_color));
-    frame_vtx.append(sf::Vertex(x_arrow_end2, axes_color));
-
-    // Draw the Y-axis
-    frame_vtx.append(sf::Vertex(y_start, axes_color));
-    frame_vtx.append(sf::Vertex(y_end, axes_color));
-
-    // Draw the arrowhead for the Y-axis
-    sf::Vector2f y_arrow_start1(
-        y_end.x + ARROW_SIZE * cos(angle_rad + M_PI / 2) -
-            ARROW_SIZE * sin(angle_rad + M_PI / 2),
-        y_end.y + ARROW_SIZE * sin(angle_rad + M_PI / 2) +
-            ARROW_SIZE * cos(angle_rad + M_PI / 2));
-    sf::Vector2f y_arrow_end1(y_end.x, y_end.y);
-    frame_vtx.append(sf::Vertex(y_arrow_start1, axes_color));
-    frame_vtx.append(sf::Vertex(y_arrow_end1, axes_color));
-
-    sf::Vector2f y_arrow_start2(
-        y_end.x + ARROW_SIZE * cos(angle_rad + M_PI / 2) +
-            ARROW_SIZE * sin(angle_rad + M_PI / 2),
-        y_end.y + ARROW_SIZE * sin(angle_rad + M_PI / 2) -
-            ARROW_SIZE * cos(angle_rad + M_PI / 2));
-    sf::Vector2f y_arrow_end2(y_end.x, y_end.y);
-    frame_vtx.append(sf::Vertex(y_arrow_start2, axes_color));
-    frame_vtx.append(sf::Vertex(y_arrow_end2, axes_color));
-
-    return frame_vtx;
-}
-
-/* Given a link origin and length, draw a rectangle representing the link
-   starting at the origin vertex, with a given length and angle measured from
-   the X axis.
-*/
-sf::RectangleShape gfx_link(RotaryLink lnk, sf::RenderWindow& window) {
-    // Create a rectangle shape
-    sf::RectangleShape linkRect(sf::Vector2f(
-        lnk.length_m * SFML_SCALE, 10.0f));  // Width = len, Height = 10
-
-    // Set the origin of the rectangle to the center of the left edge
-    linkRect.setOrigin(0.0f, linkRect.getSize().y / 2.0f);
-
-    // Set the position of the rectangle
-    sf::Vector2f oframe(lnk.origin_frame[0], lnk.origin_frame[1]);
-    linkRect.setPosition(_transform_point(oframe, window));
-
-    // Rotate the rectangle around its origin
-    linkRect.setRotation(-lnk.end_frame[2]);
-
-    // Return the rotated and positioned rectangle
-    return linkRect;
-}
 
 int main() {
     Vector3d origin_frame;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,11 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
+#include <SFML/Graphics.hpp>
 #include <cmath>
 #include <iostream>
 
+#include "SFML/Graphics/CircleShape.hpp"
+#include "SFML/Graphics/RenderWindow.hpp"
 #include "robotlib.h"
 
 using Eigen::Matrix2d;
@@ -11,6 +14,33 @@ using Eigen::Vector2d;
 using Eigen::Vector3d;
 
 using namespace std;
+
+sf::VertexArray xyAxis(sf::RenderWindow& window) {
+    // Create the X and Y axes
+    sf::VertexArray xyAxis(sf::Lines, 4);
+
+    // Set the position of the axes
+    float xAxisLength = window.getSize().x;
+    float yAxisLength = window.getSize().y;
+    float xOffset = window.getSize().x / 2.f;
+    float yOffset = window.getSize().y / 2.f;
+
+    // Define the X axis
+    xyAxis[0].position = sf::Vector2f(-xAxisLength, yOffset);
+    xyAxis[1].position = sf::Vector2f(xAxisLength, yOffset);
+
+    // Define the Y axis
+    xyAxis[2].position = sf::Vector2f(xOffset, -yAxisLength);
+    xyAxis[3].position = sf::Vector2f(xOffset, yAxisLength);
+
+    // Set the color of the axes
+    xyAxis[0].color = sf::Color::Blue;
+    xyAxis[1].color = sf::Color::Blue;
+    xyAxis[2].color = sf::Color::Blue;
+    xyAxis[3].color = sf::Color::Blue;
+
+    return xyAxis;
+}
 
 int main() {
     Vector3d joint_angles_current(0, 0, 0);
@@ -29,6 +59,27 @@ int main() {
         cout << "Far solution: " << endl << sol_far << endl;
     } else {
         cout << "No solution!" << endl;
+    }
+    auto window = sf::RenderWindow{{800, 600u}, "Robot Intro!"};
+    window.setFramerateLimit(144);
+
+    while (window.isOpen()) {
+        for (auto event = sf::Event{}; window.pollEvent(event);) {
+            if (event.type == sf::Event::Closed) {
+                window.close();
+            }
+        }
+
+        window.clear();
+
+        sf::CircleShape shape(50.f);
+        shape.setFillColor(sf::Color(100, 250, 50));
+        // draw things here:
+        sf::VertexArray axs = xyAxis(window);
+        window.draw(axs);
+        window.draw(shape);
+
+        window.display();
     }
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,9 +151,9 @@ int main() {
     Planar3DOFManipulator m(link_lengths_m, origin_frame);
     Vector3d joint_angles_deg(45, -30, 0);
     /* m.move_joints(joint_angles_deg); */
-    cout << m.end_effector_position() << endl;
+    cout << m.base_to_end_effector() << endl;
     m.set_tool(Vector3d(0.1, 0.2, 30));
-    cout << m.tool_position() << endl;
+    cout << m.base_to_tool() << endl;
 
     sf::RenderWindow window(sf::VideoMode(800, 600), "Robot Intro!");
     window.setFramerateLimit(144);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,10 +165,10 @@ class RotaryLink {
     }
 
    private:
-    Vector3d _get_end_frame(Vector3d& origin_frame) {
-        double dx = length_m * cos(theta_rad + radians(origin_frame[2]));
-        double dy = length_m * sin(theta_rad + radians(origin_frame[2]));
-        return origin_frame + Vector3d(dx, dy, degrees(theta_rad));
+    Vector3d _get_end_frame(Vector3d& base_to_origin) {
+        Vector3d origin_to_end(length_m * cos(theta_rad),
+                               length_m * sin(theta_rad), degrees(theta_rad));
+        return itou(tmult(base_to_origin, origin_to_end));
     }
 };
 
@@ -178,8 +178,6 @@ int main() {
     /* Vector3d& ef = L1.end_frame; */
     RotaryLink L2(L1.end_frame, 0.5);
     RotaryLink L3(L2.end_frame, 0);
-    cout << L1.end_frame << endl;  // 0.5, 0, 0
-    cout << L2.end_frame << endl;  // 1, 0, 0
     L1.rotate(45);
     L2.rotate(-30);
     L3.rotate(35);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,10 @@
 #include <iostream>
 
 #include "SFML/Graphics/CircleShape.hpp"
+#include "SFML/Graphics/RectangleShape.hpp"
 #include "SFML/Graphics/RenderWindow.hpp"
+#include "SFML/Graphics/Vertex.hpp"
+#include "SFML/System/Vector2.hpp"
 #include "robotlib.h"
 
 using Eigen::Matrix2d;
@@ -14,6 +17,9 @@ using Eigen::Vector2d;
 using Eigen::Vector3d;
 
 using namespace std;
+
+// multiply meters by this number to get into graphics.
+const double SFML_SCALE = 400.f;
 
 sf::VertexArray xyAxis(sf::RenderWindow& window) {
     // Create the X and Y axes
@@ -40,6 +46,36 @@ sf::VertexArray xyAxis(sf::RenderWindow& window) {
     xyAxis[3].color = sf::Color::Blue;
 
     return xyAxis;
+}
+
+sf::Vector2f _transform_point(sf::Vector2f point_m, sf::RenderWindow& window) {
+    sf::Vector2u win_size = window.getSize();
+    double x_offset = win_size.x / 2.f + point_m.x * SFML_SCALE;
+    double y_offset = win_size.y / 2.f - point_m.y * SFML_SCALE;
+
+    return sf::Vector2f(x_offset, y_offset);
+}
+
+/* Given a link origin and length, draw a rectangle representing the link
+   starting at the origin vertex, with a given length and angle measured from
+   the X axis.
+*/
+sf::RectangleShape link(sf::Vector2f origin, double len_m, double angle_deg) {
+    // Create a rectangle shape
+    sf::RectangleShape linkRect(
+        sf::Vector2f(len_m * SFML_SCALE, 10.0f));  // Width = len, Height = 10
+
+    // Set the origin of the rectangle to the center of the left edge
+    linkRect.setOrigin(0.0f, linkRect.getSize().y / 2.0f);
+
+    // Set the position of the rectangle
+    linkRect.setPosition(origin);
+
+    // Rotate the rectangle around its origin
+    linkRect.setRotation(-angle_deg);
+
+    // Return the rotated and positioned rectangle
+    return linkRect;
 }
 
 int main() {
@@ -72,12 +108,15 @@ int main() {
 
         window.clear();
 
-        sf::CircleShape shape(50.f);
-        shape.setFillColor(sf::Color(100, 250, 50));
         // draw things here:
         sf::VertexArray axs = xyAxis(window);
+        sf::RectangleShape lnk_1 =
+            link(_transform_point(sf::Vector2f(0, 0), window), 0.5, 30);
+        sf::RectangleShape lnk_2 =
+            link(_transform_point(sf::Vector2f(0.433, 0.25), window), 0.5, 60);
         window.draw(axs);
-        window.draw(shape);
+        window.draw(lnk_1);
+        window.draw(lnk_2);
 
         window.display();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,6 @@ using namespace std;
 
 // multiply meters by this number to get into graphics.
 const double SFML_SCALE = 300.f;
-const double MAX_JOINT_SPEED_DEG_FRAME = 0.2;
 
 sf::VertexArray world_axis(sf::RenderWindow& window, sf::Color axes_color) {
     // Create the X and Y axes
@@ -121,81 +120,6 @@ sf::VertexArray gfx_frame(Vector3d frame, sf::RenderWindow& window,
 
     return frame_vtx;
 }
-
-class RotaryLink {
-   public:
-    const double length_m;
-    double theta_rad;
-    Vector3d& origin_frame;
-    Vector3d end_frame;
-    RotaryLink(Vector3d& origin_frame, double len_m)
-        : length_m(len_m),
-          origin_frame(origin_frame),
-          end_frame(_get_end_frame(origin_frame)) {
-        theta_rad = 0.f;
-    }
-
-    void rotate(double angle_deg) {
-        theta_rad += radians(angle_deg);
-        end_frame = _get_end_frame(origin_frame);
-    }
-
-   private:
-    Vector3d _get_end_frame(Vector3d& base_to_origin) {
-        Vector3d origin_to_end(length_m * cos(theta_rad),
-                               length_m * sin(theta_rad), degrees(theta_rad));
-        return itou(tmult(base_to_origin, origin_to_end));
-    }
-};
-
-class Planar3DOFManipulator {
-   public:
-    Vector3d& base_frame;
-    RotaryLink L1;
-    RotaryLink L2;
-    RotaryLink L3;
-    Planar3DOFManipulator(Vector3d link_lengths_m, Vector3d& base_frame)
-        : base_frame(base_frame),
-          L1(base_frame, link_lengths_m[0]),
-          L2(L1.end_frame, link_lengths_m[1]),
-          L3(L2.end_frame, link_lengths_m[2]),
-          wrist_to_tool(Matrix3d()) {}
-
-    void move_joints(Vector3d joint_angles_deg) {
-        L1.rotate(joint_angles_deg[0]);
-        L2.rotate(joint_angles_deg[1]);
-        L3.rotate(joint_angles_deg[2]);
-    }
-
-    Vector3d end_effector_position() const { return L3.end_frame; }
-
-    Vector3d tool_position() const {
-        // L3.end_frame is base_to_wrist
-        // want base_to_tool
-
-        return itou(tmult(utoi(L3.end_frame), wrist_to_tool));
-    }
-
-    Vector3d joint_angles_deg() {
-        return Vector3d(degrees(L1.theta_rad), degrees(L2.theta_rad),
-                        degrees(L3.theta_rad));
-    }
-
-    void set_tool(Vector3d wrist_to_tool_u) {
-        wrist_to_tool = utoi(wrist_to_tool_u);
-    }
-
-    void move_to_angles(Vector3d target_joint_angles_deg) {
-        Vector3d dist_to_go = target_joint_angles_deg - joint_angles_deg();
-        if (abs(dist_to_go.sum()) > 0) {
-            double max_dist = dist_to_go.cwiseAbs().maxCoeff();
-            move_joints(dist_to_go / max_dist * MAX_JOINT_SPEED_DEG_FRAME);
-        }
-    }
-
-   private:
-    Matrix3d wrist_to_tool;
-};
 
 /* Given a link origin and length, draw a rectangle representing the link
    starting at the origin vertex, with a given length and angle measured from

--- a/src/robotgfx.cpp
+++ b/src/robotgfx.cpp
@@ -1,0 +1,134 @@
+#include "robotgfx.h"
+
+#include "robotlib.h"
+
+using Eigen::Vector3d;
+
+// multiply meters by this number to get into graphics.
+const double SFML_SCALE = 300.f;
+
+sf::VertexArray world_axis(sf::RenderWindow& window, sf::Color axes_color) {
+    // Create the X and Y axes
+    sf::VertexArray xyAxis(sf::Lines, 4);
+
+    // Set the position of the axes
+    float xAxisLength = window.getSize().x;
+    float yAxisLength = window.getSize().y;
+    float xOffset = window.getSize().x / 2.f;
+    float yOffset = window.getSize().y / 2.f;
+
+    // Define the X axis
+    xyAxis[0].position = sf::Vector2f(-xAxisLength, yOffset);
+    xyAxis[1].position = sf::Vector2f(xAxisLength, yOffset);
+
+    // Define the Y axis
+    xyAxis[2].position = sf::Vector2f(xOffset, -yAxisLength);
+    xyAxis[3].position = sf::Vector2f(xOffset, yAxisLength);
+
+    // Set the color of the axes
+    for (int i = 0; i < 4; i++) {
+        xyAxis[i].color = axes_color;
+    }
+
+    return xyAxis;
+}
+
+sf::Vector2f _transform_point(sf::Vector2f point_m, sf::RenderWindow& window) {
+    sf::Vector2u win_size = window.getSize();
+    double x_offset = win_size.x / 2.f + point_m.x * SFML_SCALE;
+    double y_offset = win_size.y / 2.f - point_m.y * SFML_SCALE;
+
+    return sf::Vector2f(x_offset, y_offset);
+}
+
+sf::VertexArray gfx_frame(Vector3d frame, sf::RenderWindow& window,
+                          sf::Color axes_color) {
+    const float AXIS_LENGTH = 100.0f;  // Length of the axes in pixels
+    const float ARROW_SIZE = 10.0f;    // Size of the arrowhead in pixels
+
+    sf::VertexArray frame_vtx(sf::Lines);
+
+    sf::Vector2f origin_m(frame[0], frame[1]);
+    // Transform the origin from world coordinates to SFML window coordinates
+    sf::Vector2f origin_px = _transform_point(origin_m, window);
+
+    // Calculate the rotation angle in radians
+    float angle_rad = -radians(frame[2]);
+
+    // Calculate the X-axis endpoints
+    sf::Vector2f x_start(origin_px.x, origin_px.y);
+    sf::Vector2f x_end(origin_px.x + AXIS_LENGTH * cos(angle_rad),
+                       origin_px.y + AXIS_LENGTH * sin(angle_rad));
+
+    // Calculate the Y-axis endpoints
+    sf::Vector2f y_start(origin_px.x, origin_px.y);
+    sf::Vector2f y_end(origin_px.x + AXIS_LENGTH * sin(angle_rad),
+                       origin_px.y - AXIS_LENGTH * cos(angle_rad));
+
+    // Draw the X-axis
+    frame_vtx.append(sf::Vertex(x_start, axes_color));
+    frame_vtx.append(sf::Vertex(x_end, axes_color));
+
+    // Draw the arrowhead for the X-axis
+    sf::Vector2f x_arrow_start1(
+        x_end.x - ARROW_SIZE * cos(angle_rad) - ARROW_SIZE * sin(angle_rad),
+        x_end.y - ARROW_SIZE * sin(angle_rad) + ARROW_SIZE * cos(angle_rad));
+    sf::Vector2f x_arrow_end1(x_end.x, x_end.y);
+    frame_vtx.append(sf::Vertex(x_arrow_start1, axes_color));
+    frame_vtx.append(sf::Vertex(x_arrow_end1, axes_color));
+
+    sf::Vector2f x_arrow_start2(
+        x_end.x - ARROW_SIZE * cos(angle_rad) + ARROW_SIZE * sin(angle_rad),
+        x_end.y - ARROW_SIZE * sin(angle_rad) - ARROW_SIZE * cos(angle_rad));
+    sf::Vector2f x_arrow_end2(x_end.x, x_end.y);
+    frame_vtx.append(sf::Vertex(x_arrow_start2, axes_color));
+    frame_vtx.append(sf::Vertex(x_arrow_end2, axes_color));
+
+    // Draw the Y-axis
+    frame_vtx.append(sf::Vertex(y_start, axes_color));
+    frame_vtx.append(sf::Vertex(y_end, axes_color));
+
+    // Draw the arrowhead for the Y-axis
+    sf::Vector2f y_arrow_start1(
+        y_end.x + ARROW_SIZE * cos(angle_rad + M_PI / 2) -
+            ARROW_SIZE * sin(angle_rad + M_PI / 2),
+        y_end.y + ARROW_SIZE * sin(angle_rad + M_PI / 2) +
+            ARROW_SIZE * cos(angle_rad + M_PI / 2));
+    sf::Vector2f y_arrow_end1(y_end.x, y_end.y);
+    frame_vtx.append(sf::Vertex(y_arrow_start1, axes_color));
+    frame_vtx.append(sf::Vertex(y_arrow_end1, axes_color));
+
+    sf::Vector2f y_arrow_start2(
+        y_end.x + ARROW_SIZE * cos(angle_rad + M_PI / 2) +
+            ARROW_SIZE * sin(angle_rad + M_PI / 2),
+        y_end.y + ARROW_SIZE * sin(angle_rad + M_PI / 2) -
+            ARROW_SIZE * cos(angle_rad + M_PI / 2));
+    sf::Vector2f y_arrow_end2(y_end.x, y_end.y);
+    frame_vtx.append(sf::Vertex(y_arrow_start2, axes_color));
+    frame_vtx.append(sf::Vertex(y_arrow_end2, axes_color));
+
+    return frame_vtx;
+}
+
+/* Given a link origin and length, draw a rectangle representing the link
+   starting at the origin vertex, with a given length and angle measured from
+   the X axis.
+*/
+sf::RectangleShape gfx_link(RotaryLink lnk, sf::RenderWindow& window) {
+    // Create a rectangle shape
+    sf::RectangleShape linkRect(sf::Vector2f(
+        lnk.length_m * SFML_SCALE, 10.0f));  // Width = len, Height = 10
+
+    // Set the origin of the rectangle to the center of the left edge
+    linkRect.setOrigin(0.0f, linkRect.getSize().y / 2.0f);
+
+    // Set the position of the rectangle
+    sf::Vector2f oframe(lnk.origin_frame[0], lnk.origin_frame[1]);
+    linkRect.setPosition(_transform_point(oframe, window));
+
+    // Rotate the rectangle around its origin
+    linkRect.setRotation(-lnk.end_frame[2]);
+
+    // Return the rotated and positioned rectangle
+    return linkRect;
+}

--- a/src/robotgfx.h
+++ b/src/robotgfx.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <Eigen/Dense>
+#include <SFML/Graphics.hpp>
+
+#include "robotlib.h"
+
+using Eigen::Vector3d;
+
+sf::VertexArray world_axis(sf::RenderWindow& window, sf::Color axes_color);
+sf::Vector2f _transform_point(sf::Vector2f point_m, sf::RenderWindow& window);
+sf::VertexArray gfx_frame(Vector3d frame, sf::RenderWindow& window,
+                          sf::Color axes_color);
+sf::RectangleShape gfx_link(RotaryLink lnk, sf::RenderWindow& window);

--- a/src/robotlib.cpp
+++ b/src/robotlib.cpp
@@ -176,22 +176,3 @@ std::tuple<Vector3d, Vector3d, bool> invkin(Matrix3d goal_frame,
         return std::make_tuple(sol2, sol1, true);
     }
 }
-
-class Link {
-   public:
-    const double length, twist;
-    double offset, angle;
-};
-
-class PrismaticLink : public Link {
-   public:
-    const double length, twist, angle;
-    double offset;
-    PrismaticLink(double l, double t, double a, double o);
-};
-class RotaryLink : public Link {
-   public:
-    const double length, twist, offset;
-    double angle;
-    RotaryLink(double l, double t, double a, double o);
-};

--- a/src/robotlib.h
+++ b/src/robotlib.h
@@ -25,3 +25,80 @@ std::tuple<Vector3d, Vector3d, bool> solve(Matrix3d station_to_tool_goal,
                                            Vector3d joint_angles_current,
                                            Matrix3d wrist_to_tool,
                                            Matrix3d base_to_station);
+
+const double MAX_JOINT_SPEED_DEG_FRAME = 0.2;
+
+class RotaryLink {
+   public:
+    const double length_m;
+    double theta_rad;
+    Vector3d &origin_frame;
+    Vector3d end_frame;
+    RotaryLink(Vector3d &origin_frame, double len_m)
+        : length_m(len_m),
+          origin_frame(origin_frame),
+          end_frame(_get_end_frame(origin_frame)) {
+        theta_rad = 0.f;
+    }
+
+    void rotate(double angle_deg) {
+        theta_rad += radians(angle_deg);
+        end_frame = _get_end_frame(origin_frame);
+    }
+
+   private:
+    Vector3d _get_end_frame(Vector3d &base_to_origin) {
+        Vector3d origin_to_end(length_m * cos(theta_rad),
+                               length_m * sin(theta_rad), degrees(theta_rad));
+        return itou(tmult(base_to_origin, origin_to_end));
+    }
+};
+
+class Planar3DOFManipulator {
+   public:
+    Vector3d &base_frame;
+    RotaryLink L1;
+    RotaryLink L2;
+    RotaryLink L3;
+    Planar3DOFManipulator(Vector3d link_lengths_m, Vector3d &base_frame)
+        : base_frame(base_frame),
+          L1(base_frame, link_lengths_m[0]),
+          L2(L1.end_frame, link_lengths_m[1]),
+          L3(L2.end_frame, link_lengths_m[2]),
+          wrist_to_tool(Matrix3d()) {}
+
+    void move_joints(Vector3d joint_angles_deg) {
+        L1.rotate(joint_angles_deg[0]);
+        L2.rotate(joint_angles_deg[1]);
+        L3.rotate(joint_angles_deg[2]);
+    }
+
+    Vector3d end_effector_position() const { return L3.end_frame; }
+
+    Vector3d tool_position() const {
+        // L3.end_frame is base_to_wrist
+        // want base_to_tool
+
+        return itou(tmult(utoi(L3.end_frame), wrist_to_tool));
+    }
+
+    Vector3d joint_angles_deg() {
+        return Vector3d(degrees(L1.theta_rad), degrees(L2.theta_rad),
+                        degrees(L3.theta_rad));
+    }
+
+    void set_tool(Vector3d wrist_to_tool_u) {
+        wrist_to_tool = utoi(wrist_to_tool_u);
+    }
+
+    void move_to_angles(Vector3d target_joint_angles_deg) {
+        Vector3d dist_to_go = target_joint_angles_deg - joint_angles_deg();
+        if (abs(dist_to_go.sum()) > 0) {
+            double max_dist = dist_to_go.cwiseAbs().maxCoeff();
+            move_joints(dist_to_go / max_dist * MAX_JOINT_SPEED_DEG_FRAME);
+        }
+    }
+
+   private:
+    Matrix3d wrist_to_tool;
+};

--- a/src/robotlib.h
+++ b/src/robotlib.h
@@ -16,15 +16,15 @@ Matrix3d tmult(const Matrix3d &b_rel_a, const Matrix3d &c_rel_b);
 Matrix3d tmult(const Vector3d &b_rel_a, const Vector3d &c_rel_b);
 Matrix3d itransform(const Matrix3d &m);
 Matrix3d link_transform2d(const double link_len, double theta_rad);
-Matrix3d kin(Vector3d joint_angles_deg, Vector3d link_lengths_m);
-std::tuple<Vector3d, Vector3d, bool> invkin(Matrix3d goal_frame,
-                                            Vector3d joint_angles_current,
-                                            Vector3d link_lengths_m);
-std::tuple<Vector3d, Vector3d, bool> solve(Matrix3d station_to_tool_goal,
-                                           Vector3d link_lengths_m,
-                                           Vector3d joint_angles_current,
-                                           Matrix3d wrist_to_tool,
-                                           Matrix3d base_to_station);
+const Matrix3d kin(Vector3d joint_angles_deg, Vector3d link_lengths_m);
+const std::tuple<Vector3d, Vector3d, bool> invkin(Matrix3d goal_frame,
+                                                  Vector3d joint_angles_current,
+                                                  Vector3d link_lengths_m);
+const std::tuple<Vector3d, Vector3d, bool> solve(Matrix3d station_to_tool_goal,
+                                                 Vector3d link_lengths_m,
+                                                 Vector3d joint_angles_current,
+                                                 Matrix3d wrist_to_tool,
+                                                 Matrix3d base_to_station);
 
 const double MAX_JOINT_SPEED_DEG_FRAME = 0.2;
 
@@ -65,7 +65,7 @@ class Planar3DOFManipulator {
           L1(base_frame, link_lengths_m[0]),
           L2(L1.end_frame, link_lengths_m[1]),
           L3(L2.end_frame, link_lengths_m[2]),
-          wrist_to_tool(Matrix3d()) {}
+          _wrist_to_tool(Matrix3d()) {}
 
     void move_joints(Vector3d joint_angles_deg) {
         L1.rotate(joint_angles_deg[0]);
@@ -73,25 +73,31 @@ class Planar3DOFManipulator {
         L3.rotate(joint_angles_deg[2]);
     }
 
-    Vector3d end_effector_position() const { return L3.end_frame; }
+    Vector3d base_to_end_effector() const { return L3.end_frame; }
 
-    Vector3d tool_position() const {
+    Vector3d base_to_tool() const {
         // L3.end_frame is base_to_wrist
         // want base_to_tool
 
-        return itou(tmult(utoi(L3.end_frame), wrist_to_tool));
+        return itou(tmult(utoi(L3.end_frame), _wrist_to_tool));
     }
 
-    Vector3d joint_angles_deg() {
+    Vector3d joint_angles_deg() const {
         return Vector3d(degrees(L1.theta_rad), degrees(L2.theta_rad),
                         degrees(L3.theta_rad));
     }
 
-    void set_tool(Vector3d wrist_to_tool_u) {
-        wrist_to_tool = utoi(wrist_to_tool_u);
+    Vector3d link_lengths_m() const {
+        return Vector3d(L1.length_m, L2.length_m, L3.length_m);
     }
 
-    void move_to_angles(Vector3d target_joint_angles_deg) {
+    Matrix3d wrist_to_tool() const { return _wrist_to_tool; }
+
+    void set_tool(const Vector3d wrist_to_tool_u) {
+        _wrist_to_tool = utoi(wrist_to_tool_u);
+    }
+
+    void move_to_angles(const Vector3d target_joint_angles_deg) {
         Vector3d dist_to_go = target_joint_angles_deg - joint_angles_deg();
         if (abs(dist_to_go.sum()) > 0) {
             double max_dist = dist_to_go.cwiseAbs().maxCoeff();
@@ -100,5 +106,5 @@ class Planar3DOFManipulator {
     }
 
    private:
-    Matrix3d wrist_to_tool;
+    Matrix3d _wrist_to_tool;
 };


### PR DESCRIPTION
Adds basic graphical representation, as well as overloads existing functions to use the `RotaryLink` and `Planar3DOFManipulator` classes.
- **build: add SFML**
- **fixes for SFML work**
- **first steps to making drawable winOw**
- **basic graphics functionality**
- **frame representations take user form fectors**
- **first demo of RotaryLink class**
- **clean up RotaryLink**
- **planar manipulator class working, including tool**
- **graphics are now based on manipulator & link class**
- **add animation of single arm motion**
- **switch to clang for compiler to match my lsp**
- **move rotary link and manipulator classes to header file**
- **write overload functions to utilize Planar3DOFManipulator and add tests**
- **move graphics functions into separate library**
